### PR TITLE
Fixed imports and improved README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The DXOS Naming Service (DXNS) is a custom blockchain built using Cosmos SDK.
 
 ### Installation
 
-* Install latest `wire` CLI before setting up `dxnsd`.
 * [Install golang](https://golang.org/doc/install) 1.14.0+ for the required platform.
-* Test that `golang` has been successfully installed on the machine.
+* Ensure that the version installed is older than 1.16 as `crypto/hmac` panics while using `dxnscli` in older versions.
+* Test that the correct version of `golang` has been successfully installed on the machine.
 
 ```bash
 $ go version
@@ -33,7 +33,6 @@ source ~/.profile
 Clone the repo then build and install the binaries.
 
 ```bash
-$ cd ~/wireline
 $ git clone git@github.com:wirelineio/dxns.git
 $ cd dxns
 $ make install

--- a/README.md
+++ b/README.md
@@ -2,16 +2,12 @@
 
 The DXOS Naming Service (DXNS) is a custom blockchain built using Cosmos SDK.
 
-| Module   | Status | Public URL |
-| -------- | ------ | ---------- |
-| DXOS DOCS DXNS | [![Netlify Status](https://api.netlify.com/api/v1/badges/6bbab0ad-84ad-4d77-a575-420940dc55af/deploy-status)](https://app.netlify.com/sites/dxos-docs-wns/deploys) | https://dxos-docs-wns.netlify.app/wns/ |
-
 ## Getting Started
 
 ### Installation
 
 * [Install golang](https://golang.org/doc/install) 1.14.0+ for the required platform.
-* Ensure that the version installed is older than 1.16 as `crypto/hmac` panics while using `dxnscli` in older versions.
+* Ensure that the version installed is older than 1.16 as `crypto/hmac` panics while using `dxnscli` in newer versions.
 * Test that the correct version of `golang` has been successfully installed on the machine.
 
 ```bash
@@ -19,7 +15,7 @@ $ go version
 go version go1.14.9 darwin/amd64
 ```
 
-Set the followin ENV variables (if `go mod` has never been used on the machine).
+Set the following ENV variables (if `go mod` has never been used on the machine).
 
 ```bash
 mkdir -p $HOME/go/bin
@@ -33,7 +29,7 @@ source ~/.profile
 Clone the repo then build and install the binaries.
 
 ```bash
-$ git clone git@github.com:wirelineio/dxns.git
+$ git clone git@github.com:vulcanize/dxns.git
 $ cd dxns
 $ make install
 ```
@@ -83,7 +79,7 @@ $ ./scripts/server.sh stop
 
 ## Tests
 
-See https://github.com/wirelineio/registry-client#tests
+See https://github.com/vulcanize/dxns-registry-client#tests
 
 
 ## GQL Server API

--- a/gql/status.go
+++ b/gql/status.go
@@ -15,8 +15,8 @@ import (
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 
-// NodeDataPath is the path to the wnsd data folder.
-var NodeDataPath = os.ExpandEnv("$HOME/.wire/wnsd/data")
+// NodeDataPath is the path to the dxnsd data folder.
+var NodeDataPath = os.ExpandEnv("$HOME/.wire/dxnsd/data")
 
 func getStatusInfo(ctx *rpctypes.Context) (*NodeInfo, *SyncInfo, *ValidatorInfo, error) {
 	res, err := core.Status(ctx)


### PR DESCRIPTION
- Part of  #2 

- The imports have been fixed. The imports now point to `vulcanize/dxns` instead of `wirelineio/dxns`

- All scripts in `./scripts` were tested